### PR TITLE
after(:all) hook

### DIFF
--- a/gems/happybara/lib/happybara/callbacks.rb
+++ b/gems/happybara/lib/happybara/callbacks.rb
@@ -15,6 +15,8 @@ module Happybara
       case stage.to_sym
       when :each
         on(:after_each, &callback)
+      when :all
+        at_exit(&callback)
       else
         fail "Unknown :after stage '#{stage}'"
       end

--- a/gems/happybara/lib/happybara/version.rb
+++ b/gems/happybara/lib/happybara/version.rb
@@ -1,3 +1,3 @@
 module Happybara
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
A hook for post-suite cleanup. When invoked with a block, it simply
passes the block to at_exit